### PR TITLE
fix: ios 15 crash, where url can not be created

### DIFF
--- a/ios/RNColorThief.swift
+++ b/ios/RNColorThief.swift
@@ -88,7 +88,8 @@ public class RNColorThief: NSObject {
      ========================
      */
     private func getUIImage(from path: String) async -> UIImage? {
-        guard let imageURL = URL(string: path) else {
+        guard let endcodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let imageURL = URL(string: endcodedPath) else {
             return nil
         }
 


### PR DESCRIPTION
Issues with URLs Containing Hebrew Letters
Issues occur when URLs contain Hebrew letters.

Solution:

Add percent encoding to the URL string.